### PR TITLE
Fix indentation in docker-compose.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ services:
         - data:/app/data
 
 volumes:
-data:
+    data:
 ```
 
 #### Rebuilding the image

--- a/services/anki-sync-server/images/README.md
+++ b/services/anki-sync-server/images/README.md
@@ -32,7 +32,7 @@ services:
         - data:/app/data
 
 volumes:
-data:
+    data:
 ```
 
 #### Rebuilding


### PR DESCRIPTION
Without this change, the following error occurs:

    ERROR: In file './docker-compose.yml', volume must be a mapping, not a NoneType.