### PR TITLE
anki-sync-server: Change entrypoint.sh to ENTRYPOINT, add support for…

### DIFF
--- a/services/anki-sync-server/images/Dockerfile
+++ b/services/anki-sync-server/images/Dockerfile
@@ -50,7 +50,6 @@ COPY bin/entrypoint.sh ./bin/entrypoint.sh
 
 EXPOSE ${ANKISYNCD_PORT}
 
-# TODO: Change to ENTRYPOINT. Currently CMD to allow shell access if needed.
-CMD ["/bin/sh", "./bin/entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "./bin/entrypoint.sh"]
 
 HEALTHCHECK --interval=60s --timeout=3s CMD python -c "import requests; requests.get('http://127.0.0.1:${ANKISYNCD_PORT}/')"

--- a/services/anki-sync-server/images/bin/entrypoint.sh
+++ b/services/anki-sync-server/images/bin/entrypoint.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 # file: entrypoint.sh
 
+# allow entering shell if requested
+# if any arguments are given
+if [ "$#" -gt 0 ]; then
+    # and the first one seems like the same of a executable
+    # - either is itself executable
+    # - or does not exist and is a command resolveable
+    if [ -x "$1" ] || ( [ ! -e "$1" ] && command -v "$1" >/dev/null ); then
+        # execute given argument like CMD
+        # used env to ensure names like "bash" works as well as "/bin/bash"
+        exec env "$@"
+    fi
+    echo "Forward given args to anki-sync-server: $*"
+fi
+
 # if [ -f "/app/data/auth.db" ]; then
 #     echo "auth.db found"
 # else
@@ -12,4 +26,4 @@
 # python3 utils/migrate_user_tables.py
 
 echo "Starting anki-sync-server"
-python3 -m ankisyncd
+python3 -m ankisyncd "$@"


### PR DESCRIPTION
- Add mechanism into entrypoint to check the args if they compose a command
  - args given to `docker run anki-sync-server …` are forwarded by docker to the entrypoint
- If args do not compose a command, they will be forwarded to anki-sync-server
- Verified by running following command: `docker run -it --rm anki-sync-server …` with following args and results as expected:
  - `sh`: executed shell from /bin/sh (found by $PATH)
  - `/bin/bash`: executed /bin/bash because executable
  - `requirements.txt`: executed anki-sync-server with given file as arg because it exists and is not executable
  - `./requirements.txt`: same as above
  - `non-exists`: executed anki-sync-server as no valid command could be found

I expect this PR to not break any current usages because until now, no args could be forwarded and usages expecting to run a valid command (like `sh` or `/bin/bash`) should continue to work as well.